### PR TITLE
fetch 기능 추가 및 버그 수정

### DIFF
--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -40,9 +40,9 @@ async function baseFetch(
   return await fetch(url, optionResult);
 }
 
-async function normalizedFetch<ResponseType, BodyType = unknown>(
+async function normalizedFetch<ResponseType>(
   url: string,
-  option: CustomRequestInit<BodyType>,
+  option: CustomRequestInit,
 ): Promise<ResponseType> {
   const response = await baseFetch(url, option);
   if (!response.ok) {
@@ -77,7 +77,7 @@ export async function postFetch<BodyType, ResponseType = EmptyResponse>(
     body: undefined as BodyType,
   },
 ) {
-  return normalizedFetch<ResponseType, BodyType>(url, {
+  return normalizedFetch<ResponseType>(url, {
     ...option,
     method: 'POST',
   });
@@ -89,7 +89,7 @@ export async function patchFetch<BodyType, ResponseType = EmptyResponse>(
     body: undefined as BodyType,
   },
 ) {
-  return normalizedFetch<ResponseType, BodyType>(url, {
+  return normalizedFetch<ResponseType>(url, {
     ...option,
     method: 'PATCH',
   });

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -14,12 +14,12 @@ interface HasBodyRequestInit<BodyType> extends Omit<RequestInit, 'body'> {
   body: BodyType;
 }
 
-type CustomRequestInit<BodyType> =
+type CustomRequestInit<BodyType = unknown> =
   | EmptyBodyRequestInit
   | HasBodyRequestInit<BodyType>;
 
-function isEmptyBodyRequestInit<BodyType>(
-  customRequestInit: CustomRequestInit<BodyType>,
+function isEmptyBodyRequestInit(
+  customRequestInit: CustomRequestInit,
 ): customRequestInit is EmptyBodyRequestInit {
   return !!(
     customRequestInit.method &&
@@ -28,9 +28,9 @@ function isEmptyBodyRequestInit<BodyType>(
 }
 const EMPTY_BODY_METHOD_LIST = ['GET', 'HEAD', 'DELETE', 'OPTIONS'];
 
-async function baseFetch<BodyType>(
+async function baseFetch(
   url: string,
-  option: CustomRequestInit<BodyType>,
+  option: CustomRequestInit,
 ): Promise<Response> {
   const { body, ...restOption } = option;
   const optionResult: RequestInit = restOption;
@@ -44,7 +44,7 @@ async function normalizedFetch<ResponseType, BodyType = unknown>(
   url: string,
   option: CustomRequestInit<BodyType>,
 ): Promise<ResponseType> {
-  const response = await baseFetch<BodyType>(url, option);
+  const response = await baseFetch(url, option);
   if (!response.ok) {
     const networkError = getNetworkError(response);
     // 이 함수에서 에러 throw

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -14,7 +14,6 @@ type JSONValue =
   | JSONValue[]
   | { [key: string | number]: JSONValue };
 
-export type EmptyBody = [never];
 // body가 있으면 안되는 메서드에서는 body를 제한
 interface EmptyBodyRequestInit extends Omit<RequestInit, 'body'> {
   method: Method;
@@ -88,13 +87,13 @@ export async function deleteFetch<ResponseType>(
   return normalizedFetch<ResponseType>(url, { ...option, method: 'DELETE' });
 }
 
-type CanHasBodyFetchArgs<BodyType extends JSONValue | EmptyBody> =
-  BodyType extends EmptyBody
-    ? [url: string, option?: Omit<EmptyBodyRequestInit, 'method'>]
-    : [url: string, option: Omit<HasBodyRequestInit<BodyType>, 'method'>];
+type CanHasBodyFetchArgs<BodyType extends JSONValue | undefined> =
+  BodyType extends JSONValue
+    ? [url: string, option: Omit<HasBodyRequestInit<BodyType>, 'method'>]
+    : [url: string, option?: Omit<EmptyBodyRequestInit, 'method'>];
 
 export async function postFetch<
-  BodyType extends JSONValue | EmptyBody = EmptyBody,
+  BodyType extends JSONValue | undefined = undefined,
   ResponseType = EmptyResponse,
 >(...args: CanHasBodyFetchArgs<BodyType>) {
   const [url, options] = args;
@@ -110,7 +109,7 @@ export async function postFetch<
 }
 
 export async function patchFetch<
-  BodyType extends JSONValue | EmptyBody = EmptyBody,
+  BodyType extends JSONValue | undefined = undefined,
   ResponseType = EmptyResponse,
 >(...args: CanHasBodyFetchArgs<BodyType>) {
   const [url, options] = args;

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -6,13 +6,17 @@ type CanHasBodyMethod = 'POST' | 'PUT' | 'PATCH';
 
 type Method = EmptyBodyMethod | CanHasBodyMethod;
 
-type JSONValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JSONValue[]
-  | { [key: string | number]: JSONValue };
+// TODO: object가 아닌 number|string|null 등으로 이루어진 객체타입으로 고쳐야 함(현재 mapped 타입으로 할 시 기본 객체 적용용 안됨)
+// 기존 코드
+// type JSONValue =
+//   | string
+//   | number
+//   | boolean
+//   | null
+//   | JSONValue[]
+//   | { [key: string | number]: JSONValue };
+
+type JSONValue = object;
 
 type ResponseErrorHandler = (response?: Response) => void;
 interface CustomRequestInitBase extends RequestInit {

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -32,7 +32,7 @@ type CustomRequestInit<BodyType extends JSONValue = JSONValue> =
 function isEmptyBodyRequestInit(
   customRequestInit: CustomRequestInit,
 ): customRequestInit is EmptyBodyRequestInit {
-  return !customRequestInit.body;
+  return customRequestInit.body === undefined;
 }
 
 async function baseFetch(

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -4,40 +4,48 @@ import handleNetworkError from './handleNetworkError';
 type EmptyBodyMethod = 'GET' | 'HEAD' | 'DELETE' | 'OPTIONS';
 type CanHasBodyMethod = 'POST' | 'PUT' | 'PATCH';
 
+type Method = EmptyBodyMethod | CanHasBodyMethod;
+
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue };
 // body가 있으면 안되는 메서드에서는 body를 제한
-interface EmptyBodyRequestInit extends RequestInit {
-  method: EmptyBodyMethod;
+interface EmptyBodyRequestInit extends Omit<RequestInit, 'body'> {
+  method: Method;
   body?: never;
 }
-interface HasBodyRequestInit<BodyType> extends Omit<RequestInit, 'body'> {
-  method?: CanHasBodyMethod;
+
+interface HasBodyRequestInit<BodyType extends JSONValue>
+  extends Omit<RequestInit, 'body'> {
+  method: CanHasBodyMethod;
   body: BodyType;
 }
 
-type CustomRequestInit<BodyType = unknown> =
+type CustomRequestInit<BodyType extends JSONValue = JSONValue> =
   | EmptyBodyRequestInit
   | HasBodyRequestInit<BodyType>;
 
 function isEmptyBodyRequestInit(
   customRequestInit: CustomRequestInit,
 ): customRequestInit is EmptyBodyRequestInit {
-  return !!(
-    customRequestInit.method &&
-    EMPTY_BODY_METHOD_LIST.includes(customRequestInit.method)
-  );
+  return !customRequestInit.body;
 }
-const EMPTY_BODY_METHOD_LIST = ['GET', 'HEAD', 'DELETE', 'OPTIONS'];
 
 async function baseFetch(
   url: string,
   option: CustomRequestInit,
 ): Promise<Response> {
+  if (isEmptyBodyRequestInit(option)) {
+    return fetch(url, option);
+  }
   const { body, ...restOption } = option;
   const optionResult: RequestInit = restOption;
-  if (!isEmptyBodyRequestInit(option) && body) {
-    optionResult.body = JSON.stringify(body);
-  }
-  return await fetch(url, optionResult);
+  optionResult.body = JSON.stringify(body);
+  return fetch(url, optionResult);
 }
 
 async function normalizedFetch<ResponseType>(
@@ -59,7 +67,7 @@ async function normalizedFetch<ResponseType>(
 
 export async function getFetch<ResponseType>(
   url: string,
-  option: Omit<EmptyBodyRequestInit, 'method'> = { body: undefined },
+  option: Omit<EmptyBodyRequestInit, 'method'> = {},
 ) {
   return normalizedFetch<ResponseType>(url, { ...option, method: 'GET' });
 }
@@ -71,26 +79,46 @@ export async function deleteFetch<ResponseType>(
   return normalizedFetch<ResponseType>(url, { ...option, method: 'DELETE' });
 }
 
-export async function postFetch<BodyType, ResponseType = EmptyResponse>(
-  url: string,
-  option: Omit<HasBodyRequestInit<BodyType>, 'method'> = {
-    body: undefined as BodyType,
-  },
-) {
+type CanHasBodyFetchArgs<BodyType extends JSONValue> = BodyType extends object
+  ? [
+      url: string,
+      option: Omit<HasBodyRequestInit<BodyType>, 'method'> & {
+        body: BodyType;
+      },
+    ]
+  : [
+      url: string,
+      option?: Omit<HasBodyRequestInit<BodyType>, 'method' | 'body'>,
+    ];
+
+export async function postFetch<
+  BodyType extends JSONValue,
+  ResponseType = EmptyResponse,
+>(...args: CanHasBodyFetchArgs<BodyType>) {
+  const [url, options] = args;
+  if (!options) {
+    return normalizedFetch<ResponseType>(url, {
+      method: 'POST',
+    });
+  }
   return normalizedFetch<ResponseType>(url, {
-    ...option,
+    ...options,
     method: 'POST',
   });
 }
 
-export async function patchFetch<BodyType, ResponseType = EmptyResponse>(
-  url: string,
-  option: Omit<HasBodyRequestInit<BodyType>, 'method'> = {
-    body: undefined as BodyType,
-  },
-) {
+export async function patchFetch<
+  BodyType extends JSONValue,
+  ResponseType = EmptyResponse,
+>(...args: CanHasBodyFetchArgs<BodyType>) {
+  const [url, options] = args;
+  if (!options) {
+    return normalizedFetch<ResponseType>(url, {
+      method: 'PATCH',
+    });
+  }
   return normalizedFetch<ResponseType>(url, {
-    ...option,
+    ...options,
     method: 'PATCH',
   });
 }

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -37,17 +37,24 @@ function isEmptyBodyRequestInit(
   return customRequestInit.body === undefined;
 }
 
+const defaultHeaders = { 'Content-Type': 'application/json' };
+function getAddedDefaultHeader(option: RequestInit): RequestInit {
+  const { headers, ...restOption } = option;
+  if (!headers) return { ...restOption, headers: defaultHeaders };
+  return { ...restOption, headers: { ...defaultHeaders, ...headers } };
+}
+
 async function baseFetch(
   url: string,
   option: CustomRequestInit,
 ): Promise<Response> {
   if (isEmptyBodyRequestInit(option)) {
-    return fetch(url, option);
+    return fetch(url, getAddedDefaultHeader(option));
   }
   const { body, ...restOption } = option;
   const optionResult: RequestInit = restOption;
   optionResult.body = JSON.stringify(body);
-  return fetch(url, optionResult);
+  return fetch(url, getAddedDefaultHeader(optionResult));
 }
 
 async function normalizedFetch<ResponseType>(

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -14,14 +14,18 @@ type JSONValue =
   | JSONValue[]
   | { [key: string | number]: JSONValue };
 
+type ResponseErrorHandler = (response?: Response) => void;
+interface CustomRequestInitBase extends RequestInit {
+  handleResponseError?: ResponseErrorHandler;
+}
 // body가 있으면 안되는 메서드에서는 body를 제한
-interface EmptyBodyRequestInit extends Omit<RequestInit, 'body'> {
+interface EmptyBodyRequestInit extends Omit<CustomRequestInitBase, 'body'> {
   method: Method;
   body?: never;
 }
 
 interface HasBodyRequestInit<BodyType extends JSONValue>
-  extends Omit<RequestInit, 'body'> {
+  extends Omit<CustomRequestInitBase, 'body'> {
   method: CanHasBodyMethod;
   body: BodyType;
 }
@@ -56,15 +60,23 @@ async function baseFetch(
   return fetch(url, getAddedDefaultHeader(optionResult));
 }
 
+const handleDefaultResponseError: ResponseErrorHandler = (
+  response?: Response,
+) => {
+  if (!response) return;
+  const networkError = getNetworkError(response);
+  // 이 함수에서 에러 throw
+  handleNetworkError(networkError);
+};
+
 async function normalizedFetch<ResponseType>(
   url: string,
   option: CustomRequestInit,
 ): Promise<ResponseType> {
   const response = await baseFetch(url, option);
   if (!response.ok) {
-    const networkError = getNetworkError(response);
-    // 이 함수에서 에러 throw
-    handleNetworkError(networkError);
+    if (option.handleResponseError) option.handleResponseError(response);
+    handleDefaultResponseError(response);
   }
 
   const json = (await response.json()) as ResponseType extends EmptyResponse

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -12,7 +12,7 @@ type JSONValue =
   | boolean
   | null
   | JSONValue[]
-  | { [key: string]: JSONValue };
+  | { [key: string | number]: JSONValue };
 
 export type EmptyBody = [never];
 // body가 있으면 안되는 메서드에서는 body를 제한

--- a/src/fetches/BaseFetches.ts
+++ b/src/fetches/BaseFetches.ts
@@ -13,6 +13,8 @@ type JSONValue =
   | null
   | JSONValue[]
   | { [key: string]: JSONValue };
+
+export type EmptyBody = [never];
 // body가 있으면 안되는 메서드에서는 body를 제한
 interface EmptyBodyRequestInit extends Omit<RequestInit, 'body'> {
   method: Method;
@@ -79,20 +81,13 @@ export async function deleteFetch<ResponseType>(
   return normalizedFetch<ResponseType>(url, { ...option, method: 'DELETE' });
 }
 
-type CanHasBodyFetchArgs<BodyType extends JSONValue> = BodyType extends object
-  ? [
-      url: string,
-      option: Omit<HasBodyRequestInit<BodyType>, 'method'> & {
-        body: BodyType;
-      },
-    ]
-  : [
-      url: string,
-      option?: Omit<HasBodyRequestInit<BodyType>, 'method' | 'body'>,
-    ];
+type CanHasBodyFetchArgs<BodyType extends JSONValue | EmptyBody> =
+  BodyType extends EmptyBody
+    ? [url: string, option?: Omit<EmptyBodyRequestInit, 'method'>]
+    : [url: string, option: Omit<HasBodyRequestInit<BodyType>, 'method'>];
 
 export async function postFetch<
-  BodyType extends JSONValue,
+  BodyType extends JSONValue | EmptyBody = EmptyBody,
   ResponseType = EmptyResponse,
 >(...args: CanHasBodyFetchArgs<BodyType>) {
   const [url, options] = args;
@@ -108,7 +103,7 @@ export async function postFetch<
 }
 
 export async function patchFetch<
-  BodyType extends JSONValue,
+  BodyType extends JSONValue | EmptyBody = EmptyBody,
   ResponseType = EmptyResponse,
 >(...args: CanHasBodyFetchArgs<BodyType>) {
   const [url, options] = args;


### PR DESCRIPTION
body 제네릭을 주더라도, option이 안들어 가던 버그 수정
기존
![image](https://github.com/user-attachments/assets/a1172dd4-368f-48fb-b2a7-35c1d023911a)
현재
![image](https://github.com/user-attachments/assets/928d642e-6088-449b-9347-f6cc0260c50f)
![image](https://github.com/user-attachments/assets/85d62372-c3b7-4afa-8a99-9b3058b1da82)

기본 헤더에 'Content-Type': 'application/json' 추가

에러 핸들링을 유연하게 하기위한 fetch 내 에러 핸들링 주입 가능