### PR TITLE
채팅 페이지 fetching시 생길 수 있는 문제 해결

### DIFF
--- a/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
@@ -74,7 +74,7 @@ export default function AppChatMbtiPage() {
       postFetch<ChatMbtiRequestBody>(HTTP_API_END_POINT.mbtiChatPost(mbti), {
         body: { content: value },
       })
-        .catch(() => alert('메세지 송신에 실패하였습니다..'))
+        .catch(() => alert('메세지 발신에 실패하였습니다..'))
         .finally(() => setSendingMessage(null));
     },
     [mbti],
@@ -118,6 +118,7 @@ export default function AppChatMbtiPage() {
             onSubmit={handleSubmit}
             onValueChange={handleValueChange}
             maxTextAreaHeight={70}
+            canSend={!sendingMessage && !messages.at(-1)?.isUserChat}
           />
         </div>
       </div>

--- a/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
@@ -29,6 +29,7 @@ export default function AppChatMbtiPage() {
   const contentRef = useRef<HTMLDivElement>(null);
   const messageTextAreaRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const [sendingMessage, setSendingMessage] = useState<string | null>(null);
 
   const handleValueChange = useCallback(() => {
     if (!contentRef.current) return;
@@ -69,9 +70,12 @@ export default function AppChatMbtiPage() {
 
   const handleSubmit = useCallback(
     async (value: string) => {
+      setSendingMessage(value);
       postFetch<ChatMbtiRequestBody>(HTTP_API_END_POINT.mbtiChatPost(mbti), {
         body: { content: value },
-      });
+      })
+        .catch(() => alert('메세지 송신에 실패하였습니다..'))
+        .finally(() => setSendingMessage(null));
     },
     [mbti],
   );
@@ -104,6 +108,9 @@ export default function AppChatMbtiPage() {
               </Fragment>
             );
           })}
+          {sendingMessage && (
+            <ChatBubble content={sendingMessage} isUserChat={true} />
+          )}
           <div ref={endRef} />
         </div>
         <div className={styles['text-area']} ref={messageTextAreaRef}>

--- a/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
@@ -42,14 +42,21 @@ export default function AppChatMbtiPage() {
   }, [handleValueChange]);
 
   useEffect(() => {
+    let isFetching = false;
     async function messageUpdate() {
-      const { messageResponses } = await getFetch<ChatMbtiResponseBody>(
-        HTTP_API_END_POINT.mbtiChatGet(mbti, messages.at(-1)?.order || 0),
-      );
+      if (isFetching) return;
+      isFetching = true;
+      try {
+        const { messageResponses } = await getFetch<ChatMbtiResponseBody>(
+          HTTP_API_END_POINT.mbtiChatGet(mbti, messages.at(-1)?.order || 0),
+        );
 
-      setMessages((prev) =>
-        messageResponses.length === 0 ? prev : [...prev, ...messageResponses],
-      );
+        setMessages((prev) =>
+          messageResponses.length === 0 ? prev : [...prev, ...messageResponses],
+        );
+      } finally {
+        isFetching = false;
+      }
     }
 
     const timeoutId = setInterval(messageUpdate, 100);

--- a/src/routes/app/chat/mbti/[mbti]/_component/ChatBubble/ChatBubble.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/_component/ChatBubble/ChatBubble.tsx
@@ -8,7 +8,7 @@ export interface ChatBubbleProps
   extends Omit<HTMLProps<HTMLDivElement>, 'content'> {
   content: ReactNode;
   isUserChat: boolean;
-  timeISO: string;
+  timeISO?: string;
 }
 const getTimeStrByDate = (date: Date) => {
   let hours = date.getHours();
@@ -23,11 +23,16 @@ const getTimeStrByDate = (date: Date) => {
 
   return `${hours}:${minutes} ${period}`;
 };
+
+const getTimeStr = (timeISO: string) => {
+  const date = getDateByISO8601(timeISO);
+  const timeStr = getTimeStrByDate(date);
+  return timeStr;
+};
 export default function ChatBubble(props: ChatBubbleProps) {
   const { content, isUserChat, timeISO, className, style, ...restProps } =
     props;
-  const date = getDateByISO8601(timeISO);
-  const timeStr = getTimeStrByDate(date);
+
   return (
     <div
       className={[
@@ -38,7 +43,9 @@ export default function ChatBubble(props: ChatBubbleProps) {
       style={style}
       {...restProps}
     >
-      <span className={styles['time-span']}>{timeStr}</span>
+      <span className={styles['time-span']}>
+        {timeISO ? getTimeStr(timeISO) : null}
+      </span>
       <div className={styles['chat-bubble']}>{content}</div>
     </div>
   );

--- a/src/routes/app/chat/mbti/[mbti]/_component/MessageTextArea/MessageTextArea.module.css
+++ b/src/routes/app/chat/mbti/[mbti]/_component/MessageTextArea/MessageTextArea.module.css
@@ -65,16 +65,11 @@
 }
 
 
-.proper-message .send-button {
+.send-button.can-send {
   background-color: #4949e9;
 }
 
-.empty-message .send-button {
-  cursor          : default;
-  background-color: #c3c3c3;
-}
-
-.over-message .send-button {
+.send-button.can-not-send {
   cursor          : default;
   background-color: #c3c3c3;
 }

--- a/src/routes/app/chat/mbti/[mbti]/_component/MessageTextArea/MessageTextArea.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/_component/MessageTextArea/MessageTextArea.tsx
@@ -10,6 +10,7 @@ export interface MessageTextAreaProps
   onValueChange?: (str?: string) => void;
   textLimit?: number;
   maxTextAreaHeight?: number;
+  canSend?: boolean;
 }
 
 const getStatus = (stringLength: number, textLimit: number) => {
@@ -20,6 +21,19 @@ const getStatus = (stringLength: number, textLimit: number) => {
   return 'proper-message';
 };
 
+const getSendStatus = (
+  stringLength: number,
+  textLimit: number,
+  canSend: boolean,
+) => {
+  if (!canSend) return 'can-not-send';
+  if (stringLength === 0) return 'can-not-send';
+  if (stringLength > textLimit) {
+    return 'can-not-send';
+  }
+  return 'can-send';
+};
+
 export default function MessageTextArea(props: MessageTextAreaProps) {
   const {
     onSubmit,
@@ -28,6 +42,7 @@ export default function MessageTextArea(props: MessageTextAreaProps) {
     maxTextAreaHeight = Infinity,
     className,
     style,
+    canSend = true,
     ...restProps
   } = props;
   const [value, setValue] = useState('');
@@ -103,7 +118,13 @@ export default function MessageTextArea(props: MessageTextAreaProps) {
         <span
           className={styles['send-counter']}
         >{`${valueLength}/${textLimit}`}</span>
-        <button className={styles['send-button']} type="submit">
+        <button
+          className={[
+            styles['send-button'],
+            styles[getSendStatus(valueLength, textLimit, canSend)],
+          ].join(' ')}
+          type="submit"
+        >
           <SolidArrowSVG direction="up" />
         </button>
       </div>


### PR DESCRIPTION
## 변경사항

유저가 AI에게 질문 중일 때 추가 전송을 막음

폴링을 통해 내 데이터를 가져오는(GET 요청이 일어나는) 도중,  잠시 내 채팅이 보이지 않는 문제가 있었음. 이 지점을 해결하기 위해 메세지가 보내지는(POST 요청) 동안 유저의 응답이 보여지도록 낙관적 업데이트를 구현

### 개선 전
![image](https://github.com/user-attachments/assets/084cbc63-baa9-4747-9609-0a60f00e398f)
Polling 응답 값이 오기 전에는 유저는 자신이 보낸 채팅을 볼 수 없다가 갑자기 메세지가 나타나 깜빡거리는 현상 발생  

### 개선 후


![image](https://github.com/user-attachments/assets/d46fb786-fc81-4e45-babd-51e2db4ba039)


유저가 보낸 값을 미리 업데이트(이때, 보낸 시간은 서버에 도착한 시간이 기준이므로 POST 요청에 대한 응답이 오기 전까지 알 수 없기에 유저에게 보여주지 않음)
