### PR TITLE
채팅방 기다리는 UI 구현

### DIFF
--- a/src/components/common/WaitingDot/WaitingDot.module.css
+++ b/src/components/common/WaitingDot/WaitingDot.module.css
@@ -1,0 +1,112 @@
+.dot-container {
+  display        : flex;
+  gap            : 2.4px;
+  align-items    : center;
+  justify-content: center;
+
+  width : 60px;
+  height: 30px;
+}
+
+.dot {
+  will-change  : transform;
+  position     : relative;
+  border-radius: 100%;
+
+}
+
+
+.left {
+  animation: dot-animation-left 540ms infinite linear;
+
+}
+
+.middle {
+  animation: dot-animation-center 540ms infinite linear;
+
+}
+
+.right {
+  animation: dot-animation-right 540ms infinite linear;
+
+}
+
+@keyframes dot-animation-left {
+  0% {
+    top: 0;
+  }
+
+  16% {
+    top: 0;
+  }
+
+  33% {
+    top: 0;
+  }
+
+  50% {
+    top: 10%;
+  }
+
+  66% {
+    top: 0;
+  }
+
+
+  84% {
+    top: -10%;
+  }
+
+  100% {
+    top: 0;
+  }
+
+}
+
+@keyframes dot-animation-center {
+  0% {
+    top: 0;
+  }
+
+  16% {
+    top: 0;
+  }
+
+  32% {
+    top: 10%;
+  }
+
+  50% {
+    top: 0%;
+  }
+
+  66% {
+    top: -10%;
+  }
+
+  84% {
+    top: 0;
+  }
+}
+
+@keyframes dot-animation-right {
+  0% {
+    top: 0;
+  }
+
+  16% {
+    top: 10%;
+  }
+
+  32% {
+    top: 0%
+  }
+
+  50% {
+    top: -10%;
+  }
+
+  66% {
+    top: 0;
+  }
+}

--- a/src/components/common/WaitingDot/WaitingDot.stories.tsx
+++ b/src/components/common/WaitingDot/WaitingDot.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import WaitingDot from './WaitingDot';
+
+const meta = {
+  title: 'Common/Dot',
+  component: WaitingDot,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof WaitingDot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/common/WaitingDot/WaitingDot.tsx
+++ b/src/components/common/WaitingDot/WaitingDot.tsx
@@ -1,0 +1,27 @@
+import styles from './WaitingDot.module.css';
+
+interface WaitingDotProps {
+  color?: string;
+  circleSize?: string | number;
+}
+
+export default function WaitingDot(props: WaitingDotProps) {
+  const { color = '#4849e8', circleSize: size = '12px' } = props;
+
+  return (
+    <div className={styles['dot-container']}>
+      <div
+        className={[styles.dot, styles.left].join(' ')}
+        style={{ backgroundColor: color, width: size, height: size }}
+      />
+      <div
+        className={[styles.dot, styles.middle].join(' ')}
+        style={{ backgroundColor: color, width: size, height: size }}
+      />
+      <div
+        className={[styles.dot, styles.right].join(' ')}
+        style={{ backgroundColor: color, width: size, height: size }}
+      />
+    </div>
+  );
+}

--- a/src/constants/httpApiEndpoint.ts
+++ b/src/constants/httpApiEndpoint.ts
@@ -8,7 +8,7 @@ const HTTP_PURE_STRING_API_END_POINT = {
   mockMbtiChatWildCard: '/mock/chat/mbti/*',
   checkIsAuthed: '/user/check-session',
   getEmail: '/user/email',
-  cancelAccount: '/user/cancel',
+  cancelAccount: '/user',
   login: '/auth/login',
   logout: '/auth/logout',
   sendEmailCode: '/auth/email/code',

--- a/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
@@ -21,6 +21,8 @@ import ChatDayDiv from './_component/ChatDayDiv/ChatDayDiv';
 import ChatHeader from './_component/ChatHeader/ChatHeader';
 import MessageTextArea from './_component/MessageTextArea/MessageTextArea';
 
+type SendingPhase = 'posting' | 'wait-update' | 'complete';
+
 export default function AppChatMbtiPage() {
   const navigate = useNavigate();
 
@@ -35,6 +37,7 @@ export default function AppChatMbtiPage() {
   const [sendingMessage, setSendingMessage] = useState<string | null>(null);
   const [isShownWaitingDot, setIsShownWaitingDot] = useState(false);
   const [hasChattedThisMount, setHasChattedThisMount] = useState(false);
+  const [sendingPhase, setSendingPhase] = useState<SendingPhase>('complete');
 
   const handleValueChange = useCallback(() => {
     if (!contentRef.current) return;
@@ -56,6 +59,11 @@ export default function AppChatMbtiPage() {
         const messageResponses = await getFetch<ChatMbtiResponseBody>(
           HTTP_API_END_POINT.mbtiChatGet(mbti, messages.at(-1)?.order || 0),
         );
+
+        if (messageResponses.at(-1)?.isUserChat) {
+          setSendingMessage(null);
+          setSendingPhase('complete');
+        }
 
         setMessages((prev) =>
           messageResponses.length === 0 ? prev : [...prev, ...messageResponses],
@@ -91,12 +99,18 @@ export default function AppChatMbtiPage() {
   const handleSubmit = useCallback(
     async (value: string) => {
       setSendingMessage(value);
+      setSendingPhase('posting');
       postFetch<ChatMbtiRequestBody>(HTTP_API_END_POINT.mbtiChatPost(mbti), {
         body: { content: value },
       })
-        .catch(() => alert('메세지 발신에 실패하였습니다..'))
-        .finally(() => {
+        .then(() => setSendingPhase('wait-update'))
+        .catch(() => {
+          alert('메세지 발신에 실패하였습니다..');
+
           setSendingMessage(null);
+          setSendingPhase('complete');
+        })
+        .finally(() => {
           setHasChattedThisMount(true);
         });
     },
@@ -135,7 +149,7 @@ export default function AppChatMbtiPage() {
               </Fragment>
             );
           })}
-          {sendingMessage && (
+          {sendingPhase !== 'complete' && (
             <ChatBubble content={sendingMessage} isUserChat={true} />
           )}
           {isShownWaitingDot && messages.at(-1)?.isUserChat && (

--- a/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
@@ -6,17 +6,20 @@ import {
   useRef,
   useState,
 } from 'react';
-import { getFetch, postFetch } from '@_/fetches/BaseFetches';
 
+import { useNavigate } from 'react-router-dom';
+
+import WaitingDot from '@_/components/common/WaitingDot/WaitingDot';
+import HTTP_API_END_POINT from '@_/constants/httpApiEndpoint';
+import { getFetch, postFetch } from '@_/fetches/BaseFetches';
+import checkIsSameDay from '@_/utils/checkIsSameDay';
+import getDateByISO8601 from '@_/utils/getDateByISO8601';
+
+import styles from './ChatMbtiPage.module.css';
 import ChatBubble from './_component/ChatBubble/ChatBubble';
 import ChatDayDiv from './_component/ChatDayDiv/ChatDayDiv';
 import ChatHeader from './_component/ChatHeader/ChatHeader';
-import HTTP_API_END_POINT from '@_/constants/httpApiEndpoint';
 import MessageTextArea from './_component/MessageTextArea/MessageTextArea';
-import checkIsSameDay from '@_/utils/checkIsSameDay';
-import getDateByISO8601 from '@_/utils/getDateByISO8601';
-import styles from './ChatMbtiPage.module.css';
-import { useNavigate } from 'react-router-dom';
 
 export default function AppChatMbtiPage() {
   const navigate = useNavigate();
@@ -30,6 +33,8 @@ export default function AppChatMbtiPage() {
   const messageTextAreaRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const [sendingMessage, setSendingMessage] = useState<string | null>(null);
+  const [isShownWaitingDot, setIsShownWaitingDot] = useState(false);
+  const [hasChattedThisMount, setHasChattedThisMount] = useState(false);
 
   const handleValueChange = useCallback(() => {
     if (!contentRef.current) return;
@@ -64,6 +69,21 @@ export default function AppChatMbtiPage() {
     return () => clearInterval(timeoutId);
   }, [messages, mbti]);
 
+  useEffect(() => {
+    const lastMessage = messages.at(-1);
+    if (!lastMessage) return;
+
+    if (lastMessage.isUserChat) {
+      const id = setTimeout(
+        () => setIsShownWaitingDot(true),
+        hasChattedThisMount ? 800 : 0,
+      );
+      return () => clearTimeout(id);
+    }
+
+    setIsShownWaitingDot(false);
+  }, [messages, hasChattedThisMount]);
+
   useLayoutEffect(() => {
     endRef.current?.scrollIntoView();
   }, [messages]);
@@ -75,7 +95,10 @@ export default function AppChatMbtiPage() {
         body: { content: value },
       })
         .catch(() => alert('메세지 발신에 실패하였습니다..'))
-        .finally(() => setSendingMessage(null));
+        .finally(() => {
+          setSendingMessage(null);
+          setHasChattedThisMount(true);
+        });
     },
     [mbti],
   );
@@ -114,6 +137,9 @@ export default function AppChatMbtiPage() {
           })}
           {sendingMessage && (
             <ChatBubble content={sendingMessage} isUserChat={true} />
+          )}
+          {isShownWaitingDot && messages.at(-1)?.isUserChat && (
+            <ChatBubble content={<WaitingDot />} isUserChat={false} />
           )}
           <div ref={endRef} />
         </div>

--- a/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
@@ -76,7 +76,7 @@ export default function AppChatMbtiPage() {
     if (lastMessage.isUserChat) {
       const id = setTimeout(
         () => setIsShownWaitingDot(true),
-        hasChattedThisMount ? 800 : 0,
+        hasChattedThisMount ? 600 : 0,
       );
       return () => clearTimeout(id);
     }

--- a/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
+++ b/src/routes/app/chat/mbti/[mbti]/ChatMbtiPage.tsx
@@ -86,7 +86,7 @@ export default function AppChatMbtiPage() {
 
   useLayoutEffect(() => {
     endRef.current?.scrollIntoView();
-  }, [messages]);
+  }, [messages, isShownWaitingDot]);
 
   const handleSubmit = useCallback(
     async (value: string) => {


### PR DESCRIPTION
### 기존
유저는 채팅방 응답이 오기 전, 오랜 시간을 기다려야 했음
보통의 AI 응답 시간이 3초 정도였기에, 유저는 3초의 시간 동안 interaction이 없어 답답합을 느껴야 했음


+) 낙관적 업데이트시 POST 요청 완료에 UI가 의존해 깜빡이는 현상이 나타났음
https://github.com/user-attachments/assets/29ed3221-8927-4fd8-88ab-84a9634ae983



## 개선 후
다음의 순서로 애니메이션이 동작
1. 채팅의 낙관적 업데이트
![image](https://github.com/user-attachments/assets/3a7a035e-7399-4e3a-bd32-0e7f8e71baa7)

2. 서버 응답 기준으로 서버에 기록된 시간이 보임 (대략 낙관적 업데이트 이후 0.5초 이후)
![image](https://github.com/user-attachments/assets/ab7a5906-d80e-4348-8981-000741379424)

3. 다음과 같이 움직이는 UI를 보여줌

![image](https://github.com/user-attachments/assets/d1c04632-cf8a-42e6-b918-eb8a81bf5820)

https://github.com/user-attachments/assets/43febe2b-44c8-4b23-82c6-a7a5c21bde81



이 흐름을 통해 계속해서 앱이 동작하고 있음을 보여줌과 동시에 사용자의 흥미 저하를 완화

