### PR TITLE
회원가입 UI/UX 개선

### DIFF
--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -21,14 +21,17 @@ export default function useTimer(props: useTimerProps) {
 
     intervalRef.current = setInterval(() => {
       const nowDate = new Date();
-      const leftCnt = Math.max(0, targetDate.getTime() - nowDate.getTime());
+      const leftCnt = Math.max(
+        0,
+        Math.floor((targetDate.getTime() - nowDate.getTime()) / 1000),
+      );
       setLeftSecond(leftCnt);
       if (leftCnt === 0) {
         clearInterval(intervalRef.current);
 
         onFinish();
       }
-    }, 1000);
+    }, 100);
   }, [onFinish, targetSec]);
 
   return { resetCount, startCount, leftSecond };

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -1,0 +1,35 @@
+import { useCallback, useRef, useState } from 'react';
+
+interface useTimerProps {
+  targetSec: number;
+  onFinish?: () => void;
+}
+
+export default function useTimer(props: useTimerProps) {
+  const { targetSec, onFinish = () => {} } = props;
+  const [leftSecond, setLeftSecond] = useState(targetSec);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
+
+  const resetCount = useCallback(() => {
+    clearInterval(intervalRef.current);
+    intervalRef.current = undefined;
+  }, []);
+
+  const startCount = useCallback(() => {
+    const targetDate = new Date(new Date().getTime() + targetSec * 1000);
+
+    intervalRef.current = setInterval(() => {
+      const nowDate = new Date();
+      const leftCnt = Math.max(0, targetDate.getTime() - nowDate.getTime());
+      setLeftSecond(leftCnt);
+      if (leftCnt === 0) {
+        clearInterval(intervalRef.current);
+
+        onFinish();
+      }
+    }, 1000);
+  }, [onFinish, targetSec]);
+
+  return { resetCount, startCount, leftSecond };
+}

--- a/src/routes/app/login/LoginPage.tsx
+++ b/src/routes/app/login/LoginPage.tsx
@@ -49,6 +49,7 @@ export default function AppLoginPage() {
           onChange={(e) => setEmail(e.target.value)}
           isError={!!errorMessage}
           isLoading={isLoginSending}
+          autoFocus
         />
         <div className={styles['id-input']} />
         <ControlledInput

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -174,7 +174,6 @@ export default function AppRegisterPage() {
   });
 
   const handleGoNextStep = useCallback(async () => {
-    console.log({ nowStep, isCodeExpired, isVerified });
     if (nowStep === 2 && isCodeExpired && !isVerified) {
       return sendEmail();
     }
@@ -281,6 +280,7 @@ export default function AppRegisterPage() {
               isVerified={isVerified}
               isCodeSending={isCodeSending || isEmailSending}
               isExpired={isCodeExpired}
+              isAuto={isAutoNext}
               verify={verifyCode}
               onCodeChange={handleChangeCode}
               resetCode={resetCode}

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -108,6 +108,10 @@ export default function AppRegisterPage() {
 
   const updateMaxStep = useCallback(
     (step: Step) => {
+      if (step === maxCompletedStep) {
+        setIsAutoNext(true);
+        return;
+      }
       if (step === maxCompletedStep + 1) {
         setMaxCompletedStep(step + 1);
         setIsAutoNext(true);
@@ -157,7 +161,7 @@ export default function AppRegisterPage() {
     navigate(location.pathname, {
       state: { step: Math.min(MAX_STEP, nowStep + 1) },
     });
-    updateMaxStep((nowStep + 1) as Step);
+    updateMaxStep(nowStep);
   }, [
     nowStep,
     email,
@@ -186,6 +190,7 @@ export default function AppRegisterPage() {
   });
 
   useEffect(() => {
+    console.log({ nowStep, canGoNext, isAutoNext });
     if (nowStep !== 1 && canGoNext && isAutoNext) handleGoNextStep();
   }, [nowStep, canGoNext, isAutoNext, handleGoNextStep]);
 

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -100,22 +100,16 @@ export default function AppRegisterPage() {
 
   const [maxCompletedStep, setMaxCompletedStep] = useState(0);
 
-  const [isAutoNext, setIsAutoNext] = useState(true);
+  const isAutoNext = nowStep !== 1 && nowStep === maxCompletedStep + 1;
 
   const handleGoBackward = useCallback(() => {
-    setIsAutoNext(false);
     navigate(-1);
   }, [navigate]);
 
   const updateMaxStep = useCallback(
     (step: Step) => {
-      if (step === maxCompletedStep) {
-        setIsAutoNext(true);
-        return;
-      }
       if (step === maxCompletedStep + 1) {
-        setMaxCompletedStep(step + 1);
-        setIsAutoNext(true);
+        setMaxCompletedStep(step);
       }
     },
     [maxCompletedStep],
@@ -191,8 +185,9 @@ export default function AppRegisterPage() {
   });
 
   useEffect(() => {
-    if (nowStep !== 1 && canGoNext && isAutoNext) handleGoNextStep();
-  }, [nowStep, canGoNext, isAutoNext, handleGoNextStep]);
+    if (canGoNext && isAutoNext) handleGoNextStep();
+  }, [canGoNext, isAutoNext, handleGoNextStep]);
+  console.log(isAutoNext, nowStep, maxCompletedStep);
 
   if (nowStep > maxCompletedStep + 1)
     return <Navigate to={APP_END_POINT.register} state={{ step: 0 }} replace />;
@@ -266,14 +261,16 @@ export default function AppRegisterPage() {
           )}
         </div>
 
-        <Button
-          className={styles.button}
-          isLoading={isLoading}
-          isValid={canGoNext && (nowStep === 1 || !isAutoNext)}
-          onClick={handleGoNextStep}
-        >
-          {getButtonStr(nowStep)}
-        </Button>
+        {!isAutoNext && (
+          <Button
+            className={styles.button}
+            isLoading={isLoading}
+            isValid={canGoNext && (nowStep === 1 || !isAutoNext)}
+            onClick={handleGoNextStep}
+          >
+            {getButtonStr(nowStep)}
+          </Button>
+        )}
       </section>
     </section>
   );

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -68,6 +68,7 @@ export default function AppRegisterPage() {
     verifyCode,
     handleChangeEmail,
     handleChangeCode,
+    resetCode,
   } = useEmailVerify();
   const {
     password,
@@ -190,7 +191,6 @@ export default function AppRegisterPage() {
   });
 
   useEffect(() => {
-    console.log({ nowStep, canGoNext, isAutoNext });
     if (nowStep !== 1 && canGoNext && isAutoNext) handleGoNextStep();
   }, [nowStep, canGoNext, isAutoNext, handleGoNextStep]);
 
@@ -236,6 +236,7 @@ export default function AppRegisterPage() {
               verify={verifyCode}
               resend={sendEmail}
               onCodeChange={handleChangeCode}
+              resetCode={resetCode}
             />
           )}
           {nowStep === 3 && (
@@ -268,7 +269,7 @@ export default function AppRegisterPage() {
         <Button
           className={styles.button}
           isLoading={isLoading}
-          isValid={canGoNext}
+          isValid={canGoNext && (nowStep === 1 || !isAutoNext)}
           onClick={handleGoNextStep}
         >
           {getButtonStr(nowStep)}

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -22,14 +22,39 @@ import RegisterPasswordPage from './_pages/RegisterPasswordPage/RegisterPassword
 type Step = 1 | 2 | 3 | 4;
 const noop = () => {};
 const MAX_STEP = 4;
-const getButtonStr = (step: Step) => {
+const getButtonStr = (step: Step, isCodeExpired: boolean) => {
   if (step === 1) return '인증번호 받기';
-  if (step === 2) return '확인';
+  if (step === 2) {
+    if (isCodeExpired) return '인증메일 다시 받기';
+    return '확인';
+  }
   if (step === MAX_STEP) return '회원가입 완료하기';
   return '다음으로';
 };
 
 const checkIsButtonDisabled = ({
+  step,
+  isValidEmail,
+  isVerified,
+  isValidPassword,
+  isValidMBTI,
+  isCodeExpired,
+}: {
+  step: Step;
+  isValidEmail: boolean;
+  isVerified: boolean;
+  isValidPassword: boolean;
+  isValidMBTI: boolean;
+  isCodeExpired: boolean;
+}) => {
+  if (step === 1 && !isValidEmail) return true;
+  if (step === 2 && !isVerified && !isCodeExpired) return true;
+  if (step === 3 && !isValidPassword) return true;
+  if (step === 4 && !isValidMBTI) return true;
+  return false;
+};
+
+const checkIsFilled = ({
   step,
   isValidEmail,
   isVerified,
@@ -42,12 +67,13 @@ const checkIsButtonDisabled = ({
   isValidPassword: boolean;
   isValidMBTI: boolean;
 }) => {
-  if (step === 1 && !isValidEmail) return true;
-  if (step === 2 && !isVerified) return true;
-  if (step === 3 && !isValidPassword) return true;
-  if (step === 4 && !isValidMBTI) return true;
+  if (step === 1 && isValidEmail) return true;
+  if (step === 2 && isVerified) return true;
+  if (step === 3 && isValidPassword) return true;
+  if (step === 4 && isValidMBTI) return true;
   return false;
 };
+
 export default function AppRegisterPage() {
   useNonLoginPage();
   const navigate = useNavigate();
@@ -64,6 +90,7 @@ export default function AppRegisterPage() {
     isVerified,
     hasCodeError,
     codeErrorMessage,
+    isCodeExpired,
     sendEmail,
     verifyCode,
     handleChangeEmail,
@@ -114,8 +141,43 @@ export default function AppRegisterPage() {
     },
     [maxCompletedStep],
   );
+  const isLoading =
+    (nowStep === 1 && isEmailSending) ||
+    (nowStep === 2 && isEmailSending) ||
+    (nowStep === 4 && isRegisterSending);
+
+  const isFilled = checkIsFilled({
+    step: nowStep,
+    isValidEmail: !!(email && !hasEmailFormatError && email !== usedEmail),
+    isVerified,
+    isValidPassword: !!(
+      password &&
+      passwordChecker &&
+      !hasPasswordError &&
+      !hasPasswordCheckerError
+    ),
+    isValidMBTI: !!(mbti && isMBTICompleted),
+  });
+
+  const isButtonDisabled = checkIsButtonDisabled({
+    step: nowStep,
+    isValidEmail: !!(email && !hasEmailFormatError && email !== usedEmail),
+    isVerified,
+    isValidPassword: !!(
+      password &&
+      passwordChecker &&
+      !hasPasswordError &&
+      !hasPasswordCheckerError
+    ),
+    isValidMBTI: !!(mbti && isMBTICompleted),
+    isCodeExpired,
+  });
 
   const handleGoNextStep = useCallback(async () => {
+    console.log({ nowStep, isCodeExpired, isVerified });
+    if (nowStep === 2 && isCodeExpired && !isVerified) {
+      return sendEmail();
+    }
     if (nowStep === 1) {
       try {
         await sendEmail();
@@ -162,32 +224,22 @@ export default function AppRegisterPage() {
     email,
     password,
     mbti,
+    isVerified,
+    isCodeExpired,
     navigate,
     sendEmail,
     updateMaxStep,
     location.pathname,
   ]);
 
-  const isLoading =
-    (nowStep === 1 && isEmailSending) || (nowStep === 4 && isRegisterSending);
-
-  const canGoNext = !checkIsButtonDisabled({
-    step: nowStep,
-    isValidEmail: !!(email && !hasEmailFormatError && email !== usedEmail),
-    isVerified,
-    isValidPassword: !!(
-      password &&
-      passwordChecker &&
-      !hasPasswordError &&
-      !hasPasswordCheckerError
-    ),
-    isValidMBTI: !!(mbti && isMBTICompleted),
-  });
+  const shouldShowButton =
+    !isAutoNext || (nowStep === 2 && (leftCnt === 0 || leftSecond === 0));
 
   useEffect(() => {
-    if (canGoNext && isAutoNext) handleGoNextStep();
-  }, [canGoNext, isAutoNext, handleGoNextStep]);
-  console.log(isAutoNext, nowStep, maxCompletedStep);
+    if (isFilled && isAutoNext) {
+      handleGoNextStep();
+    }
+  }, [isFilled, isAutoNext, handleGoNextStep]);
 
   if (nowStep > maxCompletedStep + 1)
     return <Navigate to={APP_END_POINT.register} state={{ step: 0 }} replace />;
@@ -228,8 +280,8 @@ export default function AppRegisterPage() {
               leftSecond={leftSecond}
               isVerified={isVerified}
               isCodeSending={isCodeSending || isEmailSending}
+              isExpired={isCodeExpired}
               verify={verifyCode}
-              resend={sendEmail}
               onCodeChange={handleChangeCode}
               resetCode={resetCode}
             />
@@ -261,14 +313,14 @@ export default function AppRegisterPage() {
           )}
         </div>
 
-        {!isAutoNext && (
+        {shouldShowButton && (
           <Button
             className={styles.button}
             isLoading={isLoading}
-            isValid={canGoNext && (nowStep === 1 || !isAutoNext)}
+            isValid={!isButtonDisabled}
             onClick={handleGoNextStep}
           >
-            {getButtonStr(nowStep)}
+            {getButtonStr(nowStep, isCodeExpired)}
           </Button>
         )}
       </section>

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -322,6 +322,7 @@ export default function AppRegisterPage() {
               changePerspectiveChar={changePerspectiveChar}
               changeJudgeChar={changeJudgeChar}
               changePlanningChar={changePlanningChar}
+              isLoading={isRegisterSending}
             />
           )}
         </div>

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -22,8 +22,18 @@ import RegisterPasswordPage from './_pages/RegisterPasswordPage/RegisterPassword
 type Step = 1 | 2 | 3 | 4;
 const noop = () => {};
 const MAX_STEP = 4;
-const getButtonStr = (step: Step, isCodeExpired: boolean) => {
-  if (step === 1) return '인증번호 받기';
+const getButtonStr = (
+  step: Step,
+  isCodeExpired: boolean,
+  email: string | null,
+  verifiedEmail: string | null,
+) => {
+  if (step === 1) {
+    if (!verifiedEmail) return '인증번호 받기';
+    if (verifiedEmail && email !== verifiedEmail)
+      return '이 메일로 다시 인증받기';
+    return '다음으로';
+  }
   if (step === 2) {
     if (isCodeExpired) return '인증메일 다시 받기';
     return '확인';
@@ -91,6 +101,7 @@ export default function AppRegisterPage() {
     hasCodeError,
     codeErrorMessage,
     isCodeExpired,
+    verifiedEmail,
     sendEmail,
     verifyCode,
     handleChangeEmail,
@@ -174,10 +185,7 @@ export default function AppRegisterPage() {
   });
 
   const handleGoNextStep = useCallback(async () => {
-    if (nowStep === 2 && isCodeExpired && !isVerified) {
-      return sendEmail();
-    }
-    if (nowStep === 1) {
+    if (nowStep === 1 && email !== verifiedEmail) {
       try {
         await sendEmail();
         navigate(location.pathname, {
@@ -189,6 +197,9 @@ export default function AppRegisterPage() {
         noop();
         return;
       }
+    }
+    if (nowStep === 2 && isCodeExpired && !isVerified) {
+      return sendEmail();
     }
     if (nowStep === 4) {
       setIsRegisterSending(true);
@@ -225,6 +236,7 @@ export default function AppRegisterPage() {
     mbti,
     isVerified,
     isCodeExpired,
+    verifiedEmail,
     navigate,
     sendEmail,
     updateMaxStep,
@@ -261,6 +273,7 @@ export default function AppRegisterPage() {
         <div>
           {nowStep === 1 && (
             <RegisterEmailPage
+              verifiedEmail={verifiedEmail}
               email={email}
               hasEmailFormatError={hasEmailFormatError}
               usedEmail={usedEmail}
@@ -320,7 +333,7 @@ export default function AppRegisterPage() {
             isValid={!isButtonDisabled}
             onClick={handleGoNextStep}
           >
-            {getButtonStr(nowStep, isCodeExpired)}
+            {getButtonStr(nowStep, isCodeExpired, email, verifiedEmail)}
           </Button>
         )}
       </section>

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -31,7 +31,7 @@ const getButtonStr = (
   if (step === 1) {
     if (!verifiedEmail) return '인증번호 받기';
     if (verifiedEmail && email !== verifiedEmail)
-      return '이 메일로 다시 인증받기';
+      return '다른 메일로 다시 인증받기';
     return '다음으로';
   }
   if (step === 2) {

--- a/src/routes/app/register/AppRegisterPage.tsx
+++ b/src/routes/app/register/AppRegisterPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 
@@ -99,9 +99,22 @@ export default function AppRegisterPage() {
 
   const [maxCompletedStep, setMaxCompletedStep] = useState(0);
 
+  const [isAutoNext, setIsAutoNext] = useState(true);
+
   const handleGoBackward = useCallback(() => {
+    setIsAutoNext(false);
     navigate(-1);
   }, [navigate]);
+
+  const updateMaxStep = useCallback(
+    (step: Step) => {
+      if (step === maxCompletedStep + 1) {
+        setMaxCompletedStep(step + 1);
+        setIsAutoNext(true);
+      }
+    },
+    [maxCompletedStep],
+  );
 
   const handleGoNextStep = useCallback(async () => {
     if (nowStep === 1) {
@@ -110,7 +123,7 @@ export default function AppRegisterPage() {
         navigate(location.pathname, {
           state: { step: 2 },
         });
-        setMaxCompletedStep(1);
+        updateMaxStep(1);
         return;
       } catch (_) {
         noop();
@@ -133,21 +146,48 @@ export default function AppRegisterPage() {
         });
         setIsRegisterSending(false);
         navigate(APP_END_POINT.registerSuccess);
-        setMaxCompletedStep(4);
+        updateMaxStep(4);
         return;
       } catch (_) {
         setIsRegisterSending(false);
+        return;
       }
     }
 
     navigate(location.pathname, {
       state: { step: Math.min(MAX_STEP, nowStep + 1) },
     });
-    setMaxCompletedStep((prev) => Math.max(prev, nowStep + 1));
-  }, [nowStep, email, password, mbti, navigate, sendEmail, location.pathname]);
+    updateMaxStep((nowStep + 1) as Step);
+  }, [
+    nowStep,
+    email,
+    password,
+    mbti,
+    navigate,
+    sendEmail,
+    updateMaxStep,
+    location.pathname,
+  ]);
 
   const isLoading =
     (nowStep === 1 && isEmailSending) || (nowStep === 4 && isRegisterSending);
+
+  const canGoNext = !checkIsButtonDisabled({
+    step: nowStep,
+    isValidEmail: !!(email && !hasEmailFormatError && email !== usedEmail),
+    isVerified,
+    isValidPassword: !!(
+      password &&
+      passwordChecker &&
+      !hasPasswordError &&
+      !hasPasswordCheckerError
+    ),
+    isValidMBTI: !!(mbti && isMBTICompleted),
+  });
+
+  useEffect(() => {
+    if (nowStep !== 1 && canGoNext && isAutoNext) handleGoNextStep();
+  }, [nowStep, canGoNext, isAutoNext, handleGoNextStep]);
 
   if (nowStep > maxCompletedStep + 1)
     return <Navigate to={APP_END_POINT.register} state={{ step: 0 }} replace />;
@@ -223,24 +263,7 @@ export default function AppRegisterPage() {
         <Button
           className={styles.button}
           isLoading={isLoading}
-          isValid={
-            !checkIsButtonDisabled({
-              step: nowStep,
-              isValidEmail: !!(
-                email &&
-                !hasEmailFormatError &&
-                email !== usedEmail
-              ),
-              isVerified,
-              isValidPassword: !!(
-                password &&
-                passwordChecker &&
-                !hasPasswordError &&
-                !hasPasswordCheckerError
-              ),
-              isValidMBTI: !!(mbti && isMBTICompleted),
-            })
-          }
+          isValid={canGoNext}
           onClick={handleGoNextStep}
         >
           {getButtonStr(nowStep)}

--- a/src/routes/app/register/_components/CharToggler/CharToggler.module.css
+++ b/src/routes/app/register/_components/CharToggler/CharToggler.module.css
@@ -29,6 +29,8 @@
 .char-box {
   user-select: none;
 
+  position: relative;
+
   display        : flex;
   align-items    : center;
   justify-content: center;
@@ -50,4 +52,15 @@
 
 .unselected {
   color: #666;
+}
+
+.loading {
+  position: absolute;
+
+  width        : 100%;
+  height       : 100%;
+  border-radius: 10px;
+
+  background-color: #5555;
+
 }

--- a/src/routes/app/register/_components/CharToggler/CharToggler.stories.tsx
+++ b/src/routes/app/register/_components/CharToggler/CharToggler.stories.tsx
@@ -6,10 +6,15 @@ import CharToggler, { CharTogglerProps } from './CharToggler';
 
 type TmpElementProps = Pick<
   CharTogglerProps<string>,
-  'upValue' | 'downValue' | 'description'
+  'upValue' | 'downValue' | 'description' | 'isLoading'
 >;
 
-const TmpElement = ({ upValue, downValue, description }: TmpElementProps) => {
+const TmpElement = ({
+  upValue,
+  downValue,
+  description,
+  isLoading,
+}: TmpElementProps) => {
   const [nowValue, setNowValue] = useState<string | null | undefined>(null);
   useEffect(() => {
     setNowValue(null);
@@ -23,6 +28,7 @@ const TmpElement = ({ upValue, downValue, description }: TmpElementProps) => {
         setNowValue((prev) => (prev === value ? null : value))
       }
       description={description}
+      isLoading={isLoading}
     />
   );
 };
@@ -32,6 +38,7 @@ const meta = {
     upValue: 'E',
     downValue: 'I',
     description: '에너지방향',
+    isLoading: false,
   },
   component: TmpElement,
 } satisfies Meta<typeof TmpElement>;

--- a/src/routes/app/register/_components/CharToggler/CharToggler.tsx
+++ b/src/routes/app/register/_components/CharToggler/CharToggler.tsx
@@ -5,13 +5,15 @@ export interface CharTogglerProps<T extends string> {
   downValue: T;
   nowValue: T | null | undefined;
   description: string;
+  isLoading?: boolean;
   onToggle: (value: T) => void;
 }
 
 export default function CharToggler<T extends string>(
   props: CharTogglerProps<T>,
 ) {
-  const { upValue, downValue, nowValue, description, onToggle } = props;
+  const { upValue, downValue, nowValue, description, isLoading, onToggle } =
+    props;
 
   return (
     <div className={styles.container}>
@@ -20,8 +22,9 @@ export default function CharToggler<T extends string>(
           styles['char-box'],
           styles[nowValue === upValue ? 'selected' : 'unselected'],
         ].join(' ')}
-        onClick={() => onToggle(upValue)}
+        onClick={isLoading ? undefined : () => onToggle(upValue)}
       >
+        {isLoading && <div className={styles.loading} />}
         {upValue}
       </div>
       <div className={styles.description}>{description}</div>
@@ -30,8 +33,9 @@ export default function CharToggler<T extends string>(
           styles['char-box'],
           styles[nowValue === downValue ? 'selected' : 'unselected'],
         ].join(' ')}
-        onClick={() => onToggle(downValue)}
+        onClick={isLoading ? undefined : () => onToggle(downValue)}
       >
+        {isLoading && <div className={styles.loading} />}
         {downValue}
       </div>
     </div>

--- a/src/routes/app/register/_hooks/useEmailVerify.tsx
+++ b/src/routes/app/register/_hooks/useEmailVerify.tsx
@@ -4,7 +4,7 @@ import HTTP_API_END_POINT from '@_/constants/httpApiEndpoint';
 import { postFetch } from '@_/fetches/BaseFetches';
 import useTimer from '@_/hooks/useTimer';
 
-const VERIFY_INIT_SECOND = 10;
+const VERIFY_INIT_SECOND = 5 * 60;
 const LEFT_COUNT_INIT = 5;
 
 const EMAIL_REGEX =

--- a/src/routes/app/register/_hooks/useEmailVerify.tsx
+++ b/src/routes/app/register/_hooks/useEmailVerify.tsx
@@ -110,7 +110,7 @@ export default function useEmailVerify() {
       if (leftCnt) setLeftCnt(leftCnt - 1);
       setIsCodeSending(false);
       setCanVerifyCode(true);
-      return;
+      throw _;
     }
     setCodeErrorMessage(null);
     setIsCodeSending(false);

--- a/src/routes/app/register/_hooks/useEmailVerify.tsx
+++ b/src/routes/app/register/_hooks/useEmailVerify.tsx
@@ -15,6 +15,7 @@ export default function useEmailVerify() {
   const [isEmailSending, setIsEmailSending] = useState(false);
   const [hasEmailFormatError, setHasEmailFormatError] = useState(false);
   const [usedEmail, setUsedEmail] = useState<string | null>(null);
+  const [verifiedEmail, setVerifiedEmail] = useState<string | null>(null);
 
   const [isVerified, setIsVerified] = useState(false);
   const [code, setCode] = useState<string>('');
@@ -59,6 +60,7 @@ export default function useEmailVerify() {
     setHasEmailFormatError(false);
     setCode('');
     startCodeCount();
+    setVerifiedEmail(email);
   }, [email, startCodeCount]);
 
   const verifyCode = useCallback(async () => {
@@ -131,6 +133,7 @@ export default function useEmailVerify() {
     hasCodeError,
     codeErrorMessage,
     isCodeExpired: leftCnt === 0 || codeLeftSecond === 0,
+    verifiedEmail,
     sendEmail,
     verifyCode,
     handleChangeEmail,

--- a/src/routes/app/register/_hooks/useEmailVerify.tsx
+++ b/src/routes/app/register/_hooks/useEmailVerify.tsx
@@ -1,9 +1,10 @@
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 
 import HTTP_API_END_POINT from '@_/constants/httpApiEndpoint';
 import { postFetch } from '@_/fetches/BaseFetches';
+import useTimer from '@_/hooks/useTimer';
 
-const VERIFY_INIT_SECOND = 5 * 60;
+const VERIFY_INIT_SECOND = 10;
 const LEFT_COUNT_INIT = 5;
 
 const EMAIL_REGEX =
@@ -14,36 +15,20 @@ export default function useEmailVerify() {
   const [isEmailSending, setIsEmailSending] = useState(false);
   const [hasEmailFormatError, setHasEmailFormatError] = useState(false);
   const [usedEmail, setUsedEmail] = useState<string | null>(null);
-  const [isValidCode, setIsValidCode] = useState(false);
 
   const [isVerified, setIsVerified] = useState(false);
   const [code, setCode] = useState<string>('');
   const [isCodeSending, setIsCodeSending] = useState(false);
   const [canVerifyCode, setCanVerifyCode] = useState(false);
-  const [leftSecond, setLeftSecond] = useState(0);
   const [leftCnt, setLeftCnt] = useState(LEFT_COUNT_INIT);
   const [codeErrorMessage, setCodeErrorMessage] = useState<string | null>(null);
   const hasCodeError = !!codeErrorMessage;
-  const intervalIdRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
-  useEffect(() => {
-    if (!isValidCode) return;
-    function leftTimeInterval() {
-      setLeftSecond((prev) => {
-        return Math.max(prev - 1, 0);
-      });
-    }
-    intervalIdRef.current = setInterval(leftTimeInterval, 1000);
-
-    return () => clearInterval(intervalIdRef.current);
-  }, [isValidCode]);
-
-  useEffect(() => {
-    if (isValidCode && leftSecond === 0) {
-      clearInterval(intervalIdRef.current);
-      setIsValidCode(false);
-    }
-  }, [isValidCode, leftSecond]);
+  const {
+    leftSecond: codeLeftSecond,
+    startCount: startCodeCount,
+    resetCount: resetCodeCount,
+  } = useTimer(useMemo(() => ({ targetSec: VERIFY_INIT_SECOND }), []));
 
   const sendEmail = useCallback(async () => {
     setIsEmailSending(true);
@@ -65,9 +50,7 @@ export default function useEmailVerify() {
     setIsEmailSending(false);
     setHasEmailFormatError(false);
     setUsedEmail(null);
-    setIsValidCode(true);
     setLeftCnt(LEFT_COUNT_INIT);
-    setLeftSecond(VERIFY_INIT_SECOND);
     setCanVerifyCode(true);
     setCodeErrorMessage(null);
     setIsVerified(false);
@@ -75,11 +58,12 @@ export default function useEmailVerify() {
     setIsVerified(false);
     setHasEmailFormatError(false);
     setCode('');
-  }, [email]);
+    startCodeCount();
+  }, [email, startCodeCount]);
 
   const verifyCode = useCallback(async () => {
     if (!canVerifyCode) return;
-    if (leftSecond <= 0) return;
+    if (codeLeftSecond <= 0) return;
     if (leftCnt <= 0) return;
     if (code.length !== 4) return;
     setIsCodeSending(true);
@@ -116,7 +100,8 @@ export default function useEmailVerify() {
     setIsCodeSending(false);
     setIsVerified(true);
     setHasEmailFormatError(false);
-  }, [canVerifyCode, leftSecond, code, leftCnt, email]);
+    resetCodeCount();
+  }, [canVerifyCode, codeLeftSecond, code, leftCnt, email, resetCodeCount]);
 
   const handleChangeEmail = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setEmail(e.currentTarget.value);
@@ -137,7 +122,7 @@ export default function useEmailVerify() {
     email,
     code,
     leftCnt,
-    leftSecond,
+    leftSecond: codeLeftSecond,
     hasEmailFormatError,
     usedEmail,
     isEmailSending,
@@ -145,7 +130,7 @@ export default function useEmailVerify() {
     isVerified,
     hasCodeError,
     codeErrorMessage,
-    isCodeExpired: leftCnt === 0 || leftSecond === 0,
+    isCodeExpired: leftCnt === 0 || codeLeftSecond === 0,
     sendEmail,
     verifyCode,
     handleChangeEmail,

--- a/src/routes/app/register/_hooks/useEmailVerify.tsx
+++ b/src/routes/app/register/_hooks/useEmailVerify.tsx
@@ -129,6 +129,10 @@ export default function useEmailVerify() {
     setCode(e.currentTarget.value);
   }, []);
 
+  const resetCode = useCallback(() => {
+    setCode('');
+  }, []);
+
   return {
     email,
     code,
@@ -145,5 +149,6 @@ export default function useEmailVerify() {
     verifyCode,
     handleChangeEmail,
     handleChangeCode,
+    resetCode,
   };
 }

--- a/src/routes/app/register/_hooks/useEmailVerify.tsx
+++ b/src/routes/app/register/_hooks/useEmailVerify.tsx
@@ -145,6 +145,7 @@ export default function useEmailVerify() {
     isVerified,
     hasCodeError,
     codeErrorMessage,
+    isCodeExpired: leftCnt === 0 || leftSecond === 0,
     sendEmail,
     verifyCode,
     handleChangeEmail,

--- a/src/routes/app/register/_hooks/useEmailVerify.tsx
+++ b/src/routes/app/register/_hooks/useEmailVerify.tsx
@@ -70,6 +70,11 @@ export default function useEmailVerify() {
     setLeftSecond(VERIFY_INIT_SECOND);
     setCanVerifyCode(true);
     setCodeErrorMessage(null);
+    setIsVerified(false);
+    setCodeErrorMessage(null);
+    setIsVerified(false);
+    setHasEmailFormatError(false);
+    setCode('');
   }, [email]);
 
   const verifyCode = useCallback(async () => {

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.module.css
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.module.css
@@ -10,13 +10,8 @@
 
 
 .send-container {
-  display        : flex;
-  gap            : 14px;
-  align-items    : center;
-  justify-content: space-between;
-
-  width : 96px;
-  height: 100%;
+  height       : 100%;
+  padding-right: 10px;
 }
 
 .left-time {

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
@@ -69,6 +69,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
         disabled={isVerified || leftCnt === 0}
         isLoading={isCodeSending}
         type="number"
+        autoFocus
         rightIcon={
           !isVerified && (
             <div className={styles['send-container']}>

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
@@ -1,6 +1,5 @@
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef } from 'react';
 
-import Button from '@_/components/common/Button/Button';
 import ControlledInput from '@_/components/common/Input/ControlledInput';
 import getMMSSBySecond from '@_/utils/getMMSSBySecond';
 
@@ -17,30 +16,13 @@ interface RegisterCodePageProps {
   isCodeSending: boolean;
   hasCodeError: boolean;
   codeErrorMessage: string | null;
+  isExpired: boolean;
   verify: () => Promise<void>;
-  resend: () => Promise<void>;
   onCodeChange: (e: ChangeEvent<HTMLInputElement>) => void;
   resetCode: () => void;
 }
 
 const MAX_CODE_LENGTH = 4;
-
-const getButtonMessage = (leftSecond: number, leftCnt: number) => {
-  if (leftSecond > 0 && leftCnt > 0) return '인증';
-  return '재전송';
-};
-
-const checkIsValidButton = (
-  leftSecond: number,
-  leftCnt: number,
-  code: string,
-) => {
-  if (leftSecond > 0 && leftCnt > 0 && code.length === MAX_CODE_LENGTH)
-    return true;
-  if (leftSecond === 0) return true;
-  if (leftCnt === 0) return true;
-  return false;
-};
 
 export default function RegisterCodePage(props: RegisterCodePageProps) {
   const {
@@ -51,37 +33,26 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
     hasCodeError,
     codeErrorMessage,
     isVerified,
+    isExpired,
     isCodeSending,
     verify,
-    resend,
     onCodeChange,
     resetCode,
   } = props;
 
-  const isValidButton = checkIsValidButton(leftSecond, leftCnt, code);
-  const [isChanged, setIsChanged] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const isAuto = leftSecond > 0 && leftCnt > 0 && isValidButton && isChanged;
+  const canCodeSend = !isExpired && code.length === MAX_CODE_LENGTH;
 
   useEffect(() => {
-    if (isAuto) {
+    if (canCodeSend) {
       verify().catch((_) => {
-        setIsChanged(false);
         resetCode();
         setTimeout(() => inputRef.current?.focus());
         throw _;
       });
       return;
     }
-  }, [isAuto, resetCode, verify]);
-
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      setIsChanged(true);
-      onCodeChange(e);
-    },
-    [onCodeChange],
-  );
+  }, [canCodeSend, resetCode, verify]);
 
   return (
     <>
@@ -93,9 +64,13 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
         max={9999}
         min={0}
         value={code}
-        onChange={handleChange}
+        onChange={onCodeChange}
         className={styles.input}
-        placeholder="인증번호 4자리를 입력하세요"
+        placeholder={
+          isExpired
+            ? '인증 메일을 다시 받으세요'
+            : '인증번호 4자리를 입력하세요'
+        }
         isError={hasCodeError}
         disabled={isVerified || leftCnt === 0}
         isLoading={isCodeSending}
@@ -108,29 +83,6 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
               <span className={styles['left-time']}>
                 {leftCnt ? getMMSSBySecond(leftSecond) : null}
               </span>
-              <Button
-                onClick={
-                  codeErrorMessage ===
-                  '인증 횟수를 모두 사용하였습니다\n오른쪽 버튼을 눌러 인증메일을 다시 보내주세요.'
-                    ? resend
-                    : verify
-                }
-                className={[
-                  styles['send-button'],
-                  checkIsValidButton(leftSecond, leftCnt, code) &&
-                  (!isAuto || leftCnt === 0) &&
-                  !isCodeSending
-                    ? styles.valid
-                    : '',
-                ].join(' ')}
-                isValid={
-                  checkIsValidButton(leftSecond, leftCnt, code) &&
-                  (!isAuto || leftCnt === 0)
-                }
-                isLoading={isCodeSending}
-              >
-                {getButtonMessage(leftSecond, leftCnt)}
-              </Button>
             </div>
           )
         }
@@ -143,7 +95,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
           <span className={styles['error-message']}>
             {hasCodeError && codeErrorMessage}
             <span className={styles['verified-message']}>
-              {!isAuto && isVerified && '인증완료'}
+              {!canCodeSend && isVerified && '인증완료'}
             </span>
           </span>
         </div>

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
@@ -17,6 +17,7 @@ interface RegisterCodePageProps {
   hasCodeError: boolean;
   codeErrorMessage: string | null;
   isExpired: boolean;
+  isAuto: boolean;
   verify: () => Promise<void>;
   onCodeChange: (e: ChangeEvent<HTMLInputElement>) => void;
   resetCode: () => void;
@@ -35,6 +36,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
     isVerified,
     isExpired,
     isCodeSending,
+    isAuto,
     verify,
     onCodeChange,
     resetCode,
@@ -72,7 +74,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
             : '인증번호 4자리를 입력하세요'
         }
         isError={hasCodeError}
-        disabled={isVerified || leftCnt === 0}
+        disabled={isVerified || isExpired}
         isLoading={isCodeSending}
         type="number"
         autoFocus
@@ -95,7 +97,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
           <span className={styles['error-message']}>
             {hasCodeError && codeErrorMessage}
             <span className={styles['verified-message']}>
-              {!canCodeSend && isVerified && '인증완료'}
+              {!isAuto && isVerified && '인증완료'}
             </span>
           </span>
         </div>

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 
 import Button from '@_/components/common/Button/Button';
 import ControlledInput from '@_/components/common/Input/ControlledInput';
@@ -29,7 +29,11 @@ const getButtonMessage = (leftSecond: number, leftCnt: number) => {
   return '재전송';
 };
 
-const isValidButton = (leftSecond: number, leftCnt: number, code: string) => {
+const checkIsValidButton = (
+  leftSecond: number,
+  leftCnt: number,
+  code: string,
+) => {
   if (leftSecond > 0 && leftCnt > 0 && code.length === MAX_CODE_LENGTH)
     return true;
   if (leftSecond === 0) return true;
@@ -52,6 +56,24 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
     onCodeChange,
   } = props;
 
+  const isValidButton = checkIsValidButton(leftSecond, leftCnt, code);
+  const [isChanged, setIsChanged] = useState(false);
+  useEffect(() => {
+    if (leftSecond > 0 && leftCnt > 0 && isValidButton && isChanged) {
+      verify();
+      setIsChanged(false);
+      return;
+    }
+  }, [isValidButton, leftSecond, leftCnt, isChanged, verify]);
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setIsChanged(true);
+      onCodeChange(e);
+    },
+    [onCodeChange],
+  );
+
   return (
     <>
       <RegisterDescription
@@ -62,7 +84,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
         max={9999}
         min={0}
         value={code}
-        onChange={onCodeChange}
+        onChange={handleChange}
         className={styles.input}
         placeholder="인증번호 4자리를 입력하세요"
         isError={hasCodeError}
@@ -85,11 +107,12 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
                 }
                 className={[
                   styles['send-button'],
-                  isValidButton(leftSecond, leftCnt, code) && !isCodeSending
+                  checkIsValidButton(leftSecond, leftCnt, code) &&
+                  !isCodeSending
                     ? styles.valid
                     : '',
                 ].join(' ')}
-                isValid={isValidButton(leftSecond, leftCnt, code)}
+                isValid={checkIsValidButton(leftSecond, leftCnt, code)}
                 isLoading={isCodeSending}
               >
                 {getButtonMessage(leftSecond, leftCnt)}

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
@@ -58,13 +58,14 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
 
   const isValidButton = checkIsValidButton(leftSecond, leftCnt, code);
   const [isChanged, setIsChanged] = useState(false);
+  const isAuto = leftSecond > 0 && leftCnt > 0 && isValidButton && isChanged;
   useEffect(() => {
-    if (leftSecond > 0 && leftCnt > 0 && isValidButton && isChanged) {
+    if (isAuto) {
       verify();
       setIsChanged(false);
       return;
     }
-  }, [isValidButton, leftSecond, leftCnt, isChanged, verify]);
+  }, [isAuto, verify]);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -108,7 +109,8 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
                 className={[
                   styles['send-button'],
                   checkIsValidButton(leftSecond, leftCnt, code) &&
-                  !isCodeSending
+                  !isCodeSending &&
+                  (!isAuto || leftCnt === 0)
                     ? styles.valid
                     : '',
                 ].join(' ')}

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
@@ -17,8 +17,8 @@ interface RegisterCodePageProps {
   isCodeSending: boolean;
   hasCodeError: boolean;
   codeErrorMessage: string | null;
-  verify: () => void;
-  resend: () => void;
+  verify: () => Promise<void>;
+  resend: () => Promise<void>;
   onCodeChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -61,8 +61,10 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
   const isAuto = leftSecond > 0 && leftCnt > 0 && isValidButton && isChanged;
   useEffect(() => {
     if (isAuto) {
-      verify();
-      setIsChanged(false);
+      verify().catch((_) => {
+        setIsChanged(false);
+        throw _;
+      });
       return;
     }
   }, [isAuto, verify]);
@@ -109,12 +111,15 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
                 className={[
                   styles['send-button'],
                   checkIsValidButton(leftSecond, leftCnt, code) &&
-                  !isCodeSending &&
-                  (!isAuto || leftCnt === 0)
+                  (!isAuto || leftCnt === 0) &&
+                  !isCodeSending
                     ? styles.valid
                     : '',
                 ].join(' ')}
-                isValid={checkIsValidButton(leftSecond, leftCnt, code)}
+                isValid={
+                  checkIsValidButton(leftSecond, leftCnt, code) &&
+                  (!isAuto || leftCnt === 0)
+                }
                 isLoading={isCodeSending}
               >
                 {getButtonMessage(leftSecond, leftCnt)}
@@ -131,7 +136,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
           <span className={styles['error-message']}>
             {hasCodeError && codeErrorMessage}
             <span className={styles['verified-message']}>
-              {isVerified && '인증완료'}
+              {!isAuto && isVerified && '인증완료'}
             </span>
           </span>
         </div>

--- a/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
+++ b/src/routes/app/register/_pages/RegisterCodePage/RegisterCodePage.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import Button from '@_/components/common/Button/Button';
 import ControlledInput from '@_/components/common/Input/ControlledInput';
@@ -20,6 +20,7 @@ interface RegisterCodePageProps {
   verify: () => Promise<void>;
   resend: () => Promise<void>;
   onCodeChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  resetCode: () => void;
 }
 
 const MAX_CODE_LENGTH = 4;
@@ -54,20 +55,25 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
     verify,
     resend,
     onCodeChange,
+    resetCode,
   } = props;
 
   const isValidButton = checkIsValidButton(leftSecond, leftCnt, code);
   const [isChanged, setIsChanged] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const isAuto = leftSecond > 0 && leftCnt > 0 && isValidButton && isChanged;
+
   useEffect(() => {
     if (isAuto) {
       verify().catch((_) => {
         setIsChanged(false);
+        resetCode();
+        setTimeout(() => inputRef.current?.focus());
         throw _;
       });
       return;
     }
-  }, [isAuto, verify]);
+  }, [isAuto, resetCode, verify]);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -95,6 +101,7 @@ export default function RegisterCodePage(props: RegisterCodePageProps) {
         isLoading={isCodeSending}
         type="number"
         autoFocus
+        ref={inputRef}
         rightIcon={
           !isVerified && (
             <div className={styles['send-container']}>

--- a/src/routes/app/register/_pages/RegisterEmailPage/RegisterEmailPage.module.css
+++ b/src/routes/app/register/_pages/RegisterEmailPage/RegisterEmailPage.module.css
@@ -1,4 +1,4 @@
-.error-message {
+.message {
   display: block;
 
   box-sizing : border-box;
@@ -7,7 +7,11 @@
   margin-left: 10px;
 
   font-size  : 14px;
-  font-weight: 500;
   line-height: 150%;
+}
+
+.error {
+  font-weight: 500;
   color      : #ff321b;
+
 }

--- a/src/routes/app/register/_pages/RegisterEmailPage/RegisterEmailPage.tsx
+++ b/src/routes/app/register/_pages/RegisterEmailPage/RegisterEmailPage.tsx
@@ -10,6 +10,7 @@ interface EmailPageProps {
   hasEmailFormatError: boolean;
   usedEmail: string | null;
   isEmailSending: boolean;
+  verifiedEmail: string | null;
   onEmailChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -18,6 +19,7 @@ export default function RegisterEmailPage({
   hasEmailFormatError,
   usedEmail,
   isEmailSending,
+  verifiedEmail,
   onEmailChange,
 }: EmailPageProps) {
   const isUsedEmail = email === usedEmail;
@@ -36,10 +38,22 @@ export default function RegisterEmailPage({
         autoFocus
         isLoading={isEmailSending}
       />
-      <span className={styles['error-message']}>
-        {hasEmailFormatError && '이메일 형식이 맞지 않습니다'}
-        <br />
-        {isUsedEmail && `${usedEmail}은 이미 사용 중인 이메일입니다.`}
+      <span className={styles['message']}>
+        {verifiedEmail && (
+          <>
+            {`${verifiedEmail}로 인증 받으셨습니다.`}
+            <br />
+            이메일을 수정하시면 다른 이메일로 인증받으실 수 있습니다.
+          </>
+        )}
+        {hasEmailFormatError && (
+          <div className={styles.error}>이메일 형식이 맞지 않습니다</div>
+        )}
+        {isUsedEmail && (
+          <div
+            className={styles.error}
+          >{`${usedEmail}은 이미 사용 중인 이메일입니다.`}</div>
+        )}
       </span>
     </>
   );

--- a/src/routes/app/register/_pages/RegisterEmailPage/RegisterEmailPage.tsx
+++ b/src/routes/app/register/_pages/RegisterEmailPage/RegisterEmailPage.tsx
@@ -33,6 +33,7 @@ export default function RegisterEmailPage({
         isError={hasEmailFormatError || isUsedEmail}
         onChange={onEmailChange}
         placeholder="이메일"
+        autoFocus
         isLoading={isEmailSending}
       />
       <span className={styles['error-message']}>

--- a/src/routes/app/register/_pages/RegisterMBTIPage/RegisterMBTIPage.tsx
+++ b/src/routes/app/register/_pages/RegisterMBTIPage/RegisterMBTIPage.tsx
@@ -8,6 +8,7 @@ interface RegisterMBTIPageProps {
   perspectiveChar: 'N' | 'S' | null;
   judgeChar: 'F' | 'T' | null;
   planningChar: 'P' | 'J' | null;
+  isLoading: boolean;
   changeEnergyChar: (value: 'E' | 'I') => void;
   changePerspectiveChar: (value: 'S' | 'N') => void;
   changeJudgeChar: (value: 'T' | 'F') => void;
@@ -23,6 +24,7 @@ export default function RegisterMBTIPage(props: RegisterMBTIPageProps) {
     perspectiveChar,
     judgeChar,
     planningChar,
+    isLoading,
     changeEnergyChar,
     changePerspectiveChar,
     changeJudgeChar,
@@ -41,6 +43,7 @@ export default function RegisterMBTIPage(props: RegisterMBTIPageProps) {
           downValue="I"
           nowValue={energyChar}
           description="에너지방향"
+          isLoading={isLoading}
           onToggle={canChange ? changeEnergyChar : noop}
         />
         <CharToggler
@@ -48,6 +51,7 @@ export default function RegisterMBTIPage(props: RegisterMBTIPageProps) {
           downValue="N"
           nowValue={perspectiveChar}
           description="인식"
+          isLoading={isLoading}
           onToggle={canChange ? changePerspectiveChar : noop}
         />
         <CharToggler
@@ -55,6 +59,7 @@ export default function RegisterMBTIPage(props: RegisterMBTIPageProps) {
           downValue="F"
           nowValue={judgeChar}
           description="판단"
+          isLoading={isLoading}
           onToggle={canChange ? changeJudgeChar : noop}
         />
         <CharToggler
@@ -62,6 +67,7 @@ export default function RegisterMBTIPage(props: RegisterMBTIPageProps) {
           downValue="P"
           nowValue={planningChar}
           description="계획성"
+          isLoading={isLoading}
           onToggle={canChange ? changePlanningChar : noop}
         />
       </div>

--- a/src/routes/app/register/_pages/RegisterPasswordPage/RegisterPasswordPage.tsx
+++ b/src/routes/app/register/_pages/RegisterPasswordPage/RegisterPasswordPage.tsx
@@ -38,6 +38,7 @@ export default function RegisterPasswordPage(props: RegisterPasswordPageProps) {
         onChange={onChangePassword}
         placeholder="비밀번호"
         maxLength={20}
+        autoFocus
       />
       <span className={styles['error-message']}>
         {hasPasswordError && passwordErrorMessage}


### PR DESCRIPTION
## 기존




https://github.com/user-attachments/assets/eb4766e2-b090-4b50-a324-ad8382637bf0


- 인증 버튼을 눌러 인증이 활성화 되어도 버튼을 눌렀어야 했음

- 비밀번호 재입력을 완료하고도 다음 버튼을 눌렀어야 했음

- MBTI를 다 입력하고도 확인 버튼을 눌렀어야 했음

- 영상에서는 나타나지 않지만, input의 autofocus가 되지 않았음

## 구현 사항

위에 언급한 세 과정 중에서 현재의 과정이
지금까지 입력한 과정 중 가장 마지막 과정일 경우 하단 버튼을 숨기고 바로 다음 과정으로 넘어가도록 구현

https://github.com/user-attachments/assets/365278a8-7d67-4a2c-84c5-004440056351



